### PR TITLE
Fix 101

### DIFF
--- a/client/src/components/EditorPanel.tsx
+++ b/client/src/components/EditorPanel.tsx
@@ -9,10 +9,15 @@ import { FileItem, FileSystemItem } from '../types';
 
 interface Props {
 	currentNotebook?: string;
+	currentFile: FileItem | undefined;
+	setCurrentFile: React.Dispatch<FileItem | undefined>;
 }
 
-export function EditorPanel({ currentNotebook }: Props) {
-	const [currentFile, setCurrentFile] = useState<FileItem | undefined>();
+export function EditorPanel({
+	currentNotebook,
+	currentFile,
+	setCurrentFile
+}: Props) {
 	const [selection, setSelection] = useState<FileSystemItem | undefined>();
 	const [fileExplorerVisible, setFileExplorerVisible] = useState(true);
 

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -6,20 +6,24 @@ import { CreateNotebookModal } from './components/CreateNotebookModal';
 import { ipcRenderer } from 'electron';
 import { EditorPanel } from './components/EditorPanel';
 import { getFileName } from './utils/getFileName';
+import { FileItem } from './types';
 
 function App() {
 	const [currentNotebook, setCurrentNotebook] = useState<
 		string | undefined
 	>();
+	const [currentFile, setCurrentFile] = useState<FileItem | undefined>();
 
 	const [createNotebookModalVisible, setCreateNotebookModalVisible] =
 		useState(false);
 
 	useEffect(() => {
+		ipcRenderer.removeAllListeners('createNotebook');
 		ipcRenderer.on('createNotebook', () => {
 			setCreateNotebookModalVisible(true);
 		});
 
+		ipcRenderer.removeAllListeners('openNotebook');
 		ipcRenderer.on(
 			'openNotebook',
 			(_, location: string, valid: boolean) => {
@@ -31,6 +35,7 @@ function App() {
 					return;
 				}
 
+				setCurrentFile(undefined);
 				setCurrentNotebook(location);
 			}
 		);
@@ -41,7 +46,11 @@ function App() {
 			<div className='bg-gray-700 py-1 px-4'>
 				<p>Menu</p>
 			</div>
-			<EditorPanel currentNotebook={currentNotebook} />
+			<EditorPanel
+				currentNotebook={currentNotebook}
+				currentFile={currentFile}
+				setCurrentFile={setCurrentFile}
+			/>
 			{createNotebookModalVisible && (
 				<CreateNotebookModal
 					setCurrentNotebook={setCurrentNotebook}


### PR DESCRIPTION
This PR fixes #101 

## Description
This PR fixes the bug by setting the state of `currentFile` to undefined when opening a new notebook. It does this at the expense of bad prop drilling. 

The prop drilling must be refactored as soon as possible. (see #84)