### PR TITLE
Markdown file export

### DIFF
--- a/client/src/electron/applicationMenu.ts
+++ b/client/src/electron/applicationMenu.ts
@@ -64,7 +64,13 @@ const template: MenuItemConstructorOptions[] = [
 
 					ipcMain.removeAllListeners('currentFileToExport');
 					ipcMain.on('currentFileToExport', (_, currentFile) => {
-						exportNote(window, currentFile);
+						if (currentFile) {
+							exportNote(window, currentFile);
+						} else {
+							dialog.showMessageBox(window, {
+								message: 'Please select a note to export.'
+							});
+						}
 					});
 				}
 			},

--- a/client/src/electron/applicationMenu.ts
+++ b/client/src/electron/applicationMenu.ts
@@ -1,4 +1,4 @@
-import { MenuItemConstructorOptions, Menu, dialog } from 'electron';
+import { MenuItemConstructorOptions, Menu, dialog, ipcMain } from 'electron';
 import { getConfig } from '../utils/getConfig';
 
 const template: MenuItemConstructorOptions[] = [
@@ -55,7 +55,20 @@ const template: MenuItemConstructorOptions[] = [
 				label: 'Save As'
 			},
 			{
-				label: 'Export'
+				label: 'Export',
+				click: (_, window) => {
+					if (!window) return;
+
+					window.webContents.send('exportNote');
+
+					ipcMain.removeAllListeners('currentFileToExport');
+					ipcMain.on('currentFileToExport', (_, currentFile) => {
+						console.log(
+							'From applicationMenu.ts ipcmain receive currentFileToExport:\n',
+							currentFile
+						);
+					});
+				}
 			},
 			{
 				type: 'separator'

--- a/client/src/electron/applicationMenu.ts
+++ b/client/src/electron/applicationMenu.ts
@@ -1,5 +1,6 @@
 import { MenuItemConstructorOptions, Menu, dialog, ipcMain } from 'electron';
 import { getConfig } from '../utils/getConfig';
+import { exportNote } from './handlers/exportNote';
 
 const template: MenuItemConstructorOptions[] = [
 	{
@@ -63,10 +64,7 @@ const template: MenuItemConstructorOptions[] = [
 
 					ipcMain.removeAllListeners('currentFileToExport');
 					ipcMain.on('currentFileToExport', (_, currentFile) => {
-						console.log(
-							'From applicationMenu.ts ipcmain receive currentFileToExport:\n',
-							currentFile
-						);
+						exportNote(window, currentFile);
 					});
 				}
 			},

--- a/client/src/electron/handlers/exportNote.ts
+++ b/client/src/electron/handlers/exportNote.ts
@@ -1,7 +1,25 @@
-import { BrowserWindow } from 'electron';
+import { BrowserWindow, dialog } from 'electron';
 import { FileItem } from '../../types';
+import fs from 'fs';
 
 export function exportNote(window: BrowserWindow, currentFile: FileItem) {
-	console.log('exportNote Handler: ', currentFile);
-	console.log(window);
+	dialog
+		.showSaveDialog(window, {
+			defaultPath: currentFile.name.split('.')[0],
+			filters: [
+				{ name: 'PDF', extensions: ['.pdf'] },
+				{ name: 'HTML', extensions: ['.html'] }
+			]
+		})
+		.then((result) => {
+			// TEMPORARY EXPORT, will be fixed in Markdown Parsing milestone
+			// FIX: MUST PARSE MARKDOWN TO HTML THEN PDF
+			if (result.canceled || !result.filePath) return;
+			fs.copyFile(currentFile.path, result.filePath, (err) => {
+				if (err) {
+					alert(currentFile + ' could not be exported.');
+					return;
+				}
+			});
+		});
 }

--- a/client/src/electron/handlers/exportNote.ts
+++ b/client/src/electron/handlers/exportNote.ts
@@ -1,0 +1,7 @@
+import { BrowserWindow } from 'electron';
+import { FileItem } from '../../types';
+
+export function exportNote(window: BrowserWindow, currentFile: FileItem) {
+	console.log('exportNote Handler: ', currentFile);
+	console.log(window);
+}

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -39,7 +39,12 @@ function App() {
 				setCurrentNotebook(location);
 			}
 		);
-	}, []);
+
+		ipcRenderer.removeAllListeners('exportNote');
+		ipcRenderer.on('exportNote', () => {
+			ipcRenderer.send('currentFileToExport', currentFile);
+		});
+	}, [currentFile]);
 
 	return (
 		<div className='bg-gray-800 w-screen h-screen flex'>


### PR DESCRIPTION
This features #9 

## Description
Exports a selected markdown file to either a PDF or HTML by copying the markdown's content. This will be fixed up to display the correct formatting in accordance to the exported file extension during the [Markdown Parsing milestone](https://github.com/PrivaNoteTeam/PrivaNote/milestone/6).

In addition, File Explorer needs to be updated to display the exported file should the notebook be the exported directory.
Refer to Bug issue #106 
