### PR TITLE
Fix use relative path

### DIFF
--- a/client/src/app/components/editorPanel/editor/breadcrumb/useBreadcrumb.ts
+++ b/client/src/app/components/editorPanel/editor/breadcrumb/useBreadcrumb.ts
@@ -11,9 +11,12 @@ export function useBreadcrumb({ unsaved }: Args) {
 
 	let pathSegments: any;
 	try {
-		pathSegments = useRelativePath(notebook!, currentNote!.path);
-		if (pathSegments) {
-			pathSegments = pathSegments.split(/[\/\\]/);
+		// pathSegments = useRelativePath(notebook!, currentNote!.path);
+		pathSegments = useRelativePath('', '');
+		if (pathSegments instanceof String) {
+			pathSegments.split(/[\/\\]/);
+		} else {
+			throw pathSegments();
 		}
 	} catch (err) {
 		console.log(err);

--- a/client/src/app/components/editorPanel/editor/breadcrumb/useBreadcrumb.ts
+++ b/client/src/app/components/editorPanel/editor/breadcrumb/useBreadcrumb.ts
@@ -9,9 +9,15 @@ export function useBreadcrumb({ unsaved }: Args) {
 	const [{ notebook, currentNote }] = useStore();
 	const [, editorDispatch] = useEditorStore();
 
-	const pathSegments = useRelativePath(notebook!, currentNote!.path).split(
-		/[\/\\]/
-	);
+	let pathSegments: any;
+	try {
+		pathSegments = useRelativePath(notebook!, currentNote!.path);
+		if (pathSegments) {
+			pathSegments = pathSegments.split(/[\/\\]/);
+		}
+	} catch (err) {
+		console.log(err);
+	}
 
 	const applyDirectoryClickHandler = (part: string, index: number) => {
 		return () => {

--- a/client/src/app/components/editorPanel/editor/breadcrumb/useBreadcrumb.ts
+++ b/client/src/app/components/editorPanel/editor/breadcrumb/useBreadcrumb.ts
@@ -11,8 +11,7 @@ export function useBreadcrumb({ unsaved }: Args) {
 
 	let pathSegments: any;
 	try {
-		// pathSegments = useRelativePath(notebook!, currentNote!.path);
-		pathSegments = useRelativePath('', '');
+		pathSegments = useRelativePath(notebook!, currentNote!.path);
 		if (pathSegments instanceof String) {
 			pathSegments.split(/[\/\\]/);
 		} else {

--- a/client/src/shared/utils/fileSystem/tests/useRelativePath.test.ts
+++ b/client/src/shared/utils/fileSystem/tests/useRelativePath.test.ts
@@ -1,6 +1,6 @@
 import { useRelativePath } from '../useRelativePath';
 
-describe.skip('useRelativePath', () => {
+describe('useRelativePath', () => {
 	const fullPath = '/User/admin/notebook/groceries/list.md';
 
 	test('returns path relative to base of format: /notebook/', () => {

--- a/client/src/shared/utils/fileSystem/useRelativePath.ts
+++ b/client/src/shared/utils/fileSystem/useRelativePath.ts
@@ -4,4 +4,4 @@
  */
 
 export const useRelativePath = (base: string, fullPath: string) =>
-	fullPath.substr(base.length + 1);
+	fullPath.substr(fullPath.indexOf(base));

--- a/client/src/shared/utils/fileSystem/useRelativePath.ts
+++ b/client/src/shared/utils/fileSystem/useRelativePath.ts
@@ -4,6 +4,12 @@
  */
 
 export const useRelativePath = (base: string, fullPath: string) => {
+	if (base === '' || fullPath === '') {
+		return () => {
+			throw new Error('base or fullPath is empty');
+		};
+	}
+
 	while (base.indexOf('/') != -1) {
 		base = base.replace('/', '');
 	}

--- a/client/src/shared/utils/fileSystem/useRelativePath.ts
+++ b/client/src/shared/utils/fileSystem/useRelativePath.ts
@@ -3,5 +3,10 @@
  * 	@param fullPath The absolute path of the file system item
  */
 
-export const useRelativePath = (base: string, fullPath: string) =>
-	fullPath.substr(fullPath.indexOf(base));
+export const useRelativePath = (base: string, fullPath: string) => {
+	while (base.indexOf('/') != -1) {
+		base = base.replace('/', '');
+	}
+
+	return fullPath.substr(fullPath.indexOf(base));
+};

--- a/client/src/shared/utils/fileSystem/useRelativePath.ts
+++ b/client/src/shared/utils/fileSystem/useRelativePath.ts
@@ -10,9 +10,8 @@ export const useRelativePath = (base: string, fullPath: string) => {
 		};
 	}
 
-	while (base.indexOf('/') != -1) {
-		base = base.replace('/', '');
-	}
+	base = base.slice(-1) === '/' ? base.substr(0, base.length - 1) : base;
+	base = base.split('/').pop()!;
 
 	return fullPath.substr(fullPath.indexOf(base));
 };


### PR DESCRIPTION
This PR features #140 

## Description
useRelativePath now passes all jest test written.

Also separated the split function in useBreadcrumb.ts to only split when useRelativePath returns a string and throw useRelativePath error when empty paths are provided.

This closes #140 